### PR TITLE
Fix Node.js require() issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "type": "git",
     "url": "https://github.com/fordth/jinqJs"
   },
-  "main": "jinqJs.js",
+  "main": "jinqjs.js",
   "contributors": [
     "Thomas Ford <tomspostoffice@yahoo.com>"
   ],


### PR DESCRIPTION
Requiring jinqJs in Node.js on Linux currently fails. This `require()` call:

    var jinqJs = require('jinq');

produces the following stack trace:

    Error: Cannot find module 'jinq'
        at Function.Module._resolveFilename (module.js:326:15)
        at Function.Module._load (module.js:277:25)
        at Module.require (module.js:354:17)
        at require (internal/module.js:12:17)
        at Object.<anonymous> (/home/sven/jinqjs-test/Gulpfile.js:2:12)
        at Module._compile (module.js:410:26)
        at Object.Module._extensions..js (module.js:417:10)
        at Module.load (module.js:344:32)
        at Function.Module._load (module.js:301:12)
        at Module.require (module.js:354:17)
        at require (internal/module.js:12:17)

The reason is that the `"main"` file specified in `package.json` is camel-cased while the actual file is not.

I'm not sure if the above problem can be reproduced on MacOS X or Windows, both of which I know had case-insensitive file systems in the past (HFS+ and FAT32 respectively). However it is definitely a problem on Linux (which has always used case-sensitive file systems).

This should fix #12.